### PR TITLE
fix #3 Keep original file name at file name.

### DIFF
--- a/src/anshitsu/process.py
+++ b/src/anshitsu/process.py
@@ -82,7 +82,8 @@ def process(
         except UnidentifiedImageError as e:
             raise fire.core.FireError(e)
         exif = image.getexif()
-        original_file_name = os.path.split(f)[1]
+        original_file_name = os.path.split(file)[1]
+        timestamp = now_s.strftime("%Y-%m-%d_%H-%M-%S")
         retouch = Retouch(
             image=image,
             colorautoadjust=colorautoadjust,
@@ -99,9 +100,9 @@ def process(
             os.path.join(
                 return_path,
                 "out",
-                "{0}_converted_at_{1}.jpg".format(original_file_name ,now_s.strftime("%Y-%m-%d_%H-%M-%S")),
+                "{0}_converted_at_{1}.jpg".format(original_file_name, timestamp),
             ),
-            quality=100, # Specify 100 as the highest image quality
+            quality=100,  # Specify 100 as the highest image quality
             subsampling=0,
             exif=exif,
         )

--- a/src/anshitsu/process.py
+++ b/src/anshitsu/process.py
@@ -2,6 +2,7 @@ import datetime
 import glob
 import os
 import os.path
+import re
 from typing import Optional
 
 import fire
@@ -82,7 +83,9 @@ def process(
         except UnidentifiedImageError as e:
             raise fire.core.FireError(e)
         exif = image.getexif()
-        original_file_name = os.path.split(file)[1]
+        original_filename: str = os.path.split(file)[1]
+        extension = original_filename.split(".")[-1]
+        filename = re.sub(r"\.[^.]+$", "_", original_filename) + extension
         timestamp = now_s.strftime("%Y-%m-%d_%H-%M-%S")
         retouch = Retouch(
             image=image,
@@ -100,7 +103,7 @@ def process(
             os.path.join(
                 return_path,
                 "out",
-                "{0}_converted_at_{1}.jpg".format(original_file_name, timestamp),
+                "{0}_converted_at_{1}.jpg".format(filename, timestamp),
             ),
             quality=100,  # Specify 100 as the highest image quality
             subsampling=0,

--- a/src/anshitsu/process.py
+++ b/src/anshitsu/process.py
@@ -82,6 +82,7 @@ def process(
         except UnidentifiedImageError as e:
             raise fire.core.FireError(e)
         exif = image.getexif()
+        original_file_name = os.path.split(f)[1]
         retouch = Retouch(
             image=image,
             colorautoadjust=colorautoadjust,
@@ -98,9 +99,9 @@ def process(
             os.path.join(
                 return_path,
                 "out",
-                "{0}_{1}.jpg".format(now_s.strftime("%Y-%m-%d_%H-%M-%S"), (i + 1)),
+                "{0}_converted_at_{1}.jpg".format(original_file_name ,now_s.strftime("%Y-%m-%d_%H-%M-%S")),
             ),
-            quality=100,
+            quality=100, # Specify 100 as the highest image quality
             subsampling=0,
             exif=exif,
         )


### PR DESCRIPTION
The file naming method was changed to a format where the conversion date and time are added to the original file name.