### PR TITLE
Address an error when implementing the `-version` option.

### DIFF
--- a/src/anshitsu/process.py
+++ b/src/anshitsu/process.py
@@ -61,7 +61,7 @@ def process(
         str: Message.
     """
     if version:
-        print("anshitsu version {}".format(__version__))
+        return "anshitsu version {}".format(__version__)
     if path is None:
         raise ValueError("No path specified!")
     types = ("*.jpg", "*.JPG", "*.jpeg", "*.JPEG", "*.png", "*.PNG")

--- a/src/anshitsu/process.py
+++ b/src/anshitsu/process.py
@@ -43,7 +43,7 @@ def process(
     numbers around 2.4 will make it look right.
 
     Args:
-        path (str): Directory or File Path
+        path (Optional[str], optional): Directory or File Path
         overwrite (bool, optional): Overwrite original files. Defaults to False.
         colorautoadjust (bool, optional): Use colorautoadjust algorithm. Defaults to False.
         colorstretch (bool, optional): Use colorstretch algorithm. Defaults to False.

--- a/src/anshitsu/process.py
+++ b/src/anshitsu/process.py
@@ -14,7 +14,7 @@ from anshitsu.__version__ import version as __version__
 
 
 def process(
-        path: str,
+        path: Optional[str],
         colorautoadjust: bool = False,
         colorstretch: bool = False,
         grayscale: bool = False,
@@ -62,6 +62,8 @@ def process(
     """
     if version:
         print("anshitsu version {}".format(__version__))
+    if path is None:
+        raise ValueError("No path specified!")
     types = ("*.jpg", "*.JPG", "*.jpeg", "*.JPEG", "*.png", "*.PNG")
     files_glob = []
     return_path = ""

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -70,16 +70,26 @@ def test_main_for_saving_original_files_by_overwrite_mode(capfd, setup):
 
     assert os.path.exists("./tests/pic/anshitsu_orig/dog.jpg")
 
+
 def test_main_for_exist_converted_files_by_overwrite_mode(capfd, setup):
     fire.Fire(process, ["./tests/pic/dog.jpg",  "--overwrite", "--tosaka=2.4"])
     captured = capfd.readouterr()
     error = captured.err
 
     assert os.path.exists("./tests/pic/dog.png")
-    
-def test_version(capfd, setup):
+
+
+def test_main_for_show_version(capfd, setup):
     fire.Fire(process, ["--version"])
     captured = capfd.readouterr()
     result = captured.out
-    
+
     assert "anshitsu {0}".format(version) in result
+
+
+def test_main_for_no_path(capfd, setup):
+    fire.Fire(process)
+    captured = capfd.readouterr()
+    error = captured.err
+
+    assert "No path specified!" in error


### PR DESCRIPTION
I forgot to make `path` Optional when implementing the `--version` option, and the `--version` option by itself would have resulted in an error that `--path` was not specified.

This time, while making the `--path` option Optional, I made it so that the error is raised when it is not the case except for the `--version` option.