### PR TITLE
Reduce Ashigara highlight clipping

### DIFF
--- a/src/anshitsu/process/ashigara.py
+++ b/src/anshitsu/process/ashigara.py
@@ -2,6 +2,14 @@ import numpy as np
 from PIL import Image
 
 
+def _soft_clip_highlights(image_array: np.ndarray) -> np.ndarray:
+    highlight_start = 0.82
+    compression = 3.0
+    highlights = np.maximum(image_array - highlight_start, 0.0)
+    compressed = highlights / (1.0 + highlights * compression)
+    return np.minimum(image_array, highlight_start + compressed)
+
+
 def ashigara(image: Image) -> Image:
     """
     Apply a vivid, high-contrast color grade inspired by Fujifilm Velvia 100.
@@ -12,13 +20,13 @@ def ashigara(image: Image) -> Image:
     rgb_image = image.convert("RGB")
     image_array = np.array(rgb_image, dtype="float32") / 255.0
 
-    # Increase contrast with a mild S-curve.
+    # Increase contrast with a restrained S-curve.
     image_array = 3 * image_array**2 - 2 * image_array**3
-    image_array = (image_array - 0.5) * 1.12 + 0.5
+    image_array = (image_array - 0.5) * 1.06 + 0.5
 
-    red = image_array[:, :, 0] * 1.05 + 0.005
-    green = image_array[:, :, 1] * 1.04 + 0.006
-    blue = image_array[:, :, 2] * 1.08 + 0.008
+    red = image_array[:, :, 0] * 1.03
+    green = image_array[:, :, 1] * 1.025
+    blue = image_array[:, :, 2] * 1.04
     image_array = np.stack((red, green, blue), axis=2)
 
     luminance = (
@@ -26,10 +34,11 @@ def ashigara(image: Image) -> Image:
         + image_array[:, :, 1] * 0.587
         + image_array[:, :, 2] * 0.114
     )
-    saturation = 1.28
+    saturation = 1.18
     image_array = luminance[:, :, np.newaxis] + (
         image_array - luminance[:, :, np.newaxis]
     ) * saturation
 
+    image_array = _soft_clip_highlights(image_array)
     image_array = np.clip(image_array, 0.0, 1.0)
     return Image.fromarray((image_array * 255).astype("uint8"))

--- a/tests/test_ashigara.py
+++ b/tests/test_ashigara.py
@@ -13,6 +13,13 @@ def test_ashigara_changes_rgb_color():
     assert image.getpixel((0, 0)) != (120, 120, 120)
 
 
+def test_ashigara_preserves_highlight_detail():
+    image = Image.new("RGB", (1, 1), (245, 245, 245))
+    image = ashigara(image)
+
+    assert max(image.getpixel((0, 0))) < 255
+
+
 def test_ashigara_by_rgb(setup):
     image = Image.open(
         os.path.join(".", "tests", "pic", "dog.jpg"),


### PR DESCRIPTION
## Summary
- soften Ashigara's contrast and saturation to reduce blown highlights
- add highlight soft clipping before final RGB clipping
- add a regression test for bright inputs

## Testing
- poetry run pytest -q tests/test_ashigara.py
- poetry run flake8 src/ --ignore=E501,E203,W503,W504,F841