### PR TITLE
Add monochrome and cross-process presets

### DIFF
--- a/src/anshitsu/cli.py
+++ b/src/anshitsu/cli.py
@@ -19,6 +19,7 @@ def cli(
     colorautoadjust: bool = False,
     colorstretch: bool = False,
     grayscale: bool = False,
+    orthochromatic: bool = False,
     invert: bool = False,
     color: Optional[float] = None,
     brightness: Optional[float] = None,
@@ -30,6 +31,10 @@ def cli(
     cyanotype: bool = False,
     rochester: bool = False,
     ashigara: bool = False,
+    crossprocess: bool = False,
+    apocalypse: bool = False,
+    roppongi: bool = False,
+    classic: bool = False,
     noise: Optional[float] = None,
     overwrite: bool = False,
     version: bool = False,
@@ -59,6 +64,7 @@ def cli(
         colorautoadjust (bool, optional): Correct colors using Automatic Color Equalization. Defaults to False.
         colorstretch (bool, optional): Apply gray-world white balance and color stretching. Defaults to False.
         grayscale (bool, optional): Convert to grayscale. Defaults to False.
+        orthochromatic (bool, optional): Convert to orthochromatic-style grayscale. Defaults to False.
         invert (bool, optional): Invert image colors. Defaults to False.
         color (Optional[float], optional): Adjust color. Defaults to None.
         brightness (Optional[float], optional): Adjust brightness. Defaults to None.
@@ -70,6 +76,10 @@ def cli(
         cyanotype (bool, optional): Colorize a monochrome image with cyanotype-like Prussian blue. Defaults to False.
         rochester (bool, optional): Apply a warm color grade inspired by Kodak PORTRA 400. Defaults to False.
         ashigara (bool, optional): Apply a vivid color grade inspired by Fujifilm Velvia 100. Defaults to False.
+        crossprocess (bool, optional): Apply a random cross-process-style color grade. Defaults to False.
+        apocalypse (bool, optional): Apply a red-orange Velvia 100 cross-process preset. Defaults to False.
+        roppongi (bool, optional): Apply a smooth fine-grain monochrome preset. Defaults to False.
+        classic (bool, optional): Apply a classic high-acutance monochrome preset. Defaults to False.
         noise (Optional[float], optional): Add Gaussian noise. Defaults to None.
         overwrite (bool, optional): Overwrite original files. Defaults to False.
         version (bool, optional): Show version. Defaults to False.
@@ -146,6 +156,7 @@ def cli(
             colorautoadjust=colorautoadjust,
             colorstretch=colorstretch,
             grayscale=grayscale,
+            orthochromatic=orthochromatic,
             color=color,
             contrast=contrast,
             brightness=brightness,
@@ -157,6 +168,10 @@ def cli(
             sepia=sepia,
             rochester=rochester,
             ashigara=ashigara,
+            crossprocess=crossprocess,
+            apocalypse=apocalypse,
+            roppongi=roppongi,
+            classic=classic,
             noise=noise,
             line_drawing=line_drawing,
             posterize=posterize,

--- a/src/anshitsu/process/apocalypse.py
+++ b/src/anshitsu/process/apocalypse.py
@@ -1,0 +1,67 @@
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+
+def _soft_clip_highlights(image_array: np.ndarray) -> np.ndarray:
+    """
+    Compress highlights after the warm cross-process color shift.
+
+    Parameters:
+        image_array: normalized RGB image array
+
+    Returns:
+        np.ndarray: highlight-compressed normalized RGB image array.
+    """
+    highlight_start = 0.80
+    compression = 2.6
+    highlights = np.maximum(image_array - highlight_start, 0.0)
+    compressed = highlights / (1.0 + highlights * compression)
+    return np.minimum(image_array, highlight_start + compressed)
+
+
+def apocalypse(image: Image, seed: Optional[int] = None) -> Image:
+    """
+    Apply a red-orange cross-process preset inspired by Velvia 100.
+
+    This preset leans into the orange-to-red color cast often associated with
+    cross-processing Velvia 100. It aims for a dramatic end-of-days palette:
+    hot reds, heavy oranges, suppressed blues, strong saturation, and controlled
+    highlights. The strength of the red shift varies slightly each time it runs;
+    pass a seed to make the result reproducible for tests or comparisons.
+
+    Parameters:
+        image: Image
+        seed: optional random seed
+
+    Returns:
+        Image: processed RGB image.
+    """
+    rng = np.random.default_rng(seed)
+    red_shift = float(rng.uniform(0.75, 1.25))
+    image_array = np.array(image.convert("RGB"), dtype="float32") / 255.0
+
+    image_array = np.power(np.clip(image_array, 0.0, 1.0), (0.88, 0.98, 1.18))
+    red = image_array[:, :, 0] * (1.18 + 0.10 * red_shift) + (
+        0.035 + 0.020 * red_shift
+    )
+    green = image_array[:, :, 1] * (0.98 - 0.035 * red_shift) + 0.020
+    blue = image_array[:, :, 2] * (0.78 - 0.12 * red_shift) - (
+        0.010 + 0.010 * red_shift
+    )
+    image_array = np.stack((red, green, blue), axis=2)
+    image_array = (image_array - 0.5) * (1.12 + 0.10 * red_shift) + 0.5
+
+    luminance = (
+        image_array[:, :, 0] * 0.299
+        + image_array[:, :, 1] * 0.587
+        + image_array[:, :, 2] * 0.114
+    )
+    image_array = luminance[:, :, np.newaxis] + (
+        image_array - luminance[:, :, np.newaxis]
+    ) * (1.18 + 0.20 * red_shift)
+
+    image_array = _soft_clip_highlights(image_array)
+    image_array = np.clip(image_array, 0.0, 0.992)
+    return Image.fromarray((image_array * 255).astype("uint8"))

--- a/src/anshitsu/process/classic.py
+++ b/src/anshitsu/process/classic.py
@@ -1,0 +1,65 @@
+import numpy as np
+from PIL import Image, ImageChops, ImageFilter
+
+from anshitsu.process.grayscale import grayscale
+
+
+def _classic_tone_curve(gray: np.ndarray) -> np.ndarray:
+    """
+    Apply a classic high-acutance monochrome tone curve.
+
+    Parameters:
+        gray: normalized grayscale image array
+
+    Returns:
+        np.ndarray: tone-adjusted normalized image array.
+    """
+    shadows = np.clip((gray - 0.015) / 0.985, 0.0, 1.0)
+    contrast = 3 * shadows**2 - 2 * shadows**3
+    contrast = (contrast - 0.5) * 1.12 + 0.5
+
+    highlight_start = 0.86
+    highlights = np.maximum(contrast - highlight_start, 0.0)
+    compressed = highlights / (1.0 + highlights * 1.6)
+    return np.minimum(contrast, highlight_start + compressed)
+
+
+def _add_classic_grain(image: Image, amount: float) -> Image:
+    """
+    Add visible but restrained monochrome grain to an L image.
+
+    Parameters:
+        image: L mode image
+        amount: grain strength
+
+    Returns:
+        Image: grain-adjusted L image.
+    """
+    noise_image = Image.effect_noise(image.size, amount)
+    table = [x * 2 for x in range(256)]
+    return ImageChops.multiply(image, noise_image).point(table)
+
+
+def classic(image: Image) -> Image:
+    """
+    Apply a classic monochrome preset inspired by Kodak TRI-X in Rodinal.
+
+    The preset converts the image to L mode, adds a firm but not extreme tone
+    curve, protects the brightest highlights, adds visible fine grain, and
+    applies mild sharpening. It is intended to be less aggressive than Tosaka
+    mode while keeping the traditional high-acutance feel of TRI-X developed in
+    Rodinal.
+
+    Parameters:
+        image: Image
+
+    Returns:
+        Image: processed image in L mode.
+    """
+    monochrome = grayscale(image)
+    gray = np.array(monochrome, dtype="float32") / 255.0
+    toned = np.clip(_classic_tone_curve(gray), 0.0, 1.0)
+    processed = Image.fromarray((toned * 255).astype("uint8"))
+    processed = _add_classic_grain(processed, 7.0)
+    processed = processed.filter(ImageFilter.UnsharpMask(radius=1.0, percent=70, threshold=2))
+    return processed.point(lambda value: min(value, 252))

--- a/src/anshitsu/process/cross_process.py
+++ b/src/anshitsu/process/cross_process.py
@@ -1,0 +1,76 @@
+from typing import Optional, Tuple
+
+import numpy as np
+from PIL import Image
+
+
+def _select_profile(rng: np.random.Generator) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Select a cross-process color profile and add small random variation.
+
+    Parameters:
+        rng: random number generator
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray, np.ndarray]: gamma, scale, and bias arrays.
+    """
+    profiles = (
+        (
+            np.array((0.90, 1.05, 1.22), dtype="float32"),
+            np.array((1.08, 1.16, 0.86), dtype="float32"),
+            np.array((0.020, 0.030, -0.010), dtype="float32"),
+        ),
+        (
+            np.array((1.12, 0.94, 0.88), dtype="float32"),
+            np.array((1.18, 0.88, 1.12), dtype="float32"),
+            np.array((0.025, -0.010, 0.020), dtype="float32"),
+        ),
+        (
+            np.array((0.98, 1.02, 0.84), dtype="float32"),
+            np.array((0.88, 1.10, 1.22), dtype="float32"),
+            np.array((-0.005, 0.020, 0.030), dtype="float32"),
+        ),
+    )
+    gamma, scale, bias = profiles[int(rng.integers(0, len(profiles)))]
+    gamma = gamma + rng.normal(0.0, 0.035, 3).astype("float32")
+    scale = scale + rng.normal(0.0, 0.035, 3).astype("float32")
+    bias = bias + rng.normal(0.0, 0.010, 3).astype("float32")
+    return gamma, scale, bias
+
+
+def cross_process(image: Image, seed: Optional[int] = None) -> Image:
+    """
+    Apply a random cross-process-style color grade.
+
+    Cross processing can produce unpredictable color shifts depending on film,
+    chemistry, and exposure. This preset intentionally picks one of several
+    color responses and adds small random variation each time it runs. Pass a
+    seed to make the result reproducible for tests or comparisons.
+
+    Parameters:
+        image: Image
+        seed: optional random seed
+
+    Returns:
+        Image: processed RGB image.
+    """
+    rng = np.random.default_rng(seed)
+    gamma, scale, bias = _select_profile(rng)
+
+    image_array = np.array(image.convert("RGB"), dtype="float32") / 255.0
+    image_array = np.power(np.clip(image_array, 0.0, 1.0), gamma)
+    image_array = image_array * scale + bias
+    image_array = (image_array - 0.5) * float(rng.uniform(1.12, 1.28)) + 0.5
+
+    luminance = (
+        image_array[:, :, 0] * 0.299
+        + image_array[:, :, 1] * 0.587
+        + image_array[:, :, 2] * 0.114
+    )
+    saturation = float(rng.uniform(1.15, 1.35))
+    image_array = luminance[:, :, np.newaxis] + (
+        image_array - luminance[:, :, np.newaxis]
+    ) * saturation
+
+    image_array = np.clip(image_array, 0.0, 1.0)
+    return Image.fromarray((image_array * 255).astype("uint8"))

--- a/src/anshitsu/process/orthochromatic.py
+++ b/src/anshitsu/process/orthochromatic.py
@@ -1,0 +1,34 @@
+import numpy as np
+from PIL import Image
+
+
+def orthochromatic(image: Image) -> Image:
+    """
+    Convert an image to orthochromatic-style grayscale.
+
+    Orthochromatic film is less sensitive to red light and more sensitive to
+    blue light than modern panchromatic film. This conversion darkens red tones
+    and lifts blue tones to approximate that older monochrome response.
+
+    Parameters:
+        image: Image
+
+    Returns:
+        Image: processed image in L mode.
+    """
+    if image.mode == "L":
+        return image
+
+    rgb = np.array(image.convert("RGB"), dtype="float32")
+
+    gamma = 2.2
+    rgb_l = pow(rgb / 255.0, gamma)
+
+    red = rgb_l[:, :, 0]
+    green = rgb_l[:, :, 1]
+    blue = rgb_l[:, :, 2]
+
+    gray_l = 0.05 * red + 0.55 * green + 0.40 * blue
+    gray = pow(gray_l, 1.0 / gamma) * 255
+
+    return Image.fromarray(gray.astype("uint8"))

--- a/src/anshitsu/process/processor.py
+++ b/src/anshitsu/process/processor.py
@@ -2,21 +2,26 @@ from typing import Optional, Tuple
 
 from PIL import Image
 
+from anshitsu.process.apocalypse import apocalypse
 from anshitsu.process.ashigara import ashigara
 from anshitsu.process.brightness import brightness
+from anshitsu.process.classic import classic
 from anshitsu.process.color import color
 from anshitsu.process.color_auto_adjust import color_auto_adjust
 from anshitsu.process.color_stretch import color_stretch
 from anshitsu.process.contrast import contrast
+from anshitsu.process.cross_process import cross_process
 from anshitsu.process.cyanotype import cyanotype
 from anshitsu.process.grayscale import grayscale
 from anshitsu.process.invert import invert
 from anshitsu.process.line_drawing import line_drawing
 from anshitsu.process.noise import noise
+from anshitsu.process.orthochromatic import orthochromatic
 from anshitsu.process.output_rgb import output_rgb
 from anshitsu.process.posterize import posterize
 from anshitsu.process.remove_alpha import remove_alpha
 from anshitsu.process.rochester import rochester
+from anshitsu.process.roppongi import roppongi
 from anshitsu.process.sepia import sepia
 from anshitsu.process.sharpness import sharpness
 from anshitsu.process.create_alpha_mask import create_alpha_mask
@@ -43,6 +48,7 @@ class Processor:
         colorautoadjust: bool = False,
         colorstretch: bool = False,
         grayscale: bool = False,
+        orthochromatic: bool = False,
         line_drawing: bool = False,
         invert: bool = False,
         tosaka: Optional[float] = None,
@@ -56,6 +62,10 @@ class Processor:
         cyanotype: bool = False,
         rochester: bool = False,
         ashigara: bool = False,
+        crossprocess: bool = False,
+        apocalypse: bool = False,
+        roppongi: bool = False,
+        classic: bool = False,
         posterize: Optional[int] = None,
         vignette: Optional[float] = None,
         keep_alpha: bool = False,
@@ -68,6 +78,7 @@ class Processor:
             colorautoadjust (bool, optional): Correct colors using Automatic Color Equalization. Defaults to False.
             colorstretch (bool, optional): Apply gray-world white balance and color stretching. Defaults to False.
             grayscale (bool, optional): Convert to grayscale. Defaults to False.
+            orthochromatic (bool, optional): Convert to orthochromatic-style grayscale. Defaults to False.
             line_drawing (bool, optional): Convert to a line drawing. Defaults to False.
             invert (bool, optional): Invert image colors. Defaults to False.
             tosaka (Optional[float], optional): Use Tosaka mode. Defaults to None.
@@ -81,6 +92,10 @@ class Processor:
             cyanotype (bool, optional): Colorize a monochrome image with cyanotype-like Prussian blue. Defaults to False.
             rochester (bool, optional): Apply a warm color grade inspired by Kodak PORTRA 400. Defaults to False.
             ashigara (bool, optional): Apply a vivid color grade inspired by Fujifilm Velvia 100. Defaults to False.
+            crossprocess (bool, optional): Apply a random cross-process-style color grade. Defaults to False.
+            apocalypse (bool, optional): Apply a red-orange Velvia 100 cross-process preset. Defaults to False.
+            roppongi (bool, optional): Apply a smooth fine-grain monochrome preset. Defaults to False.
+            classic (bool, optional): Apply a classic high-acutance monochrome preset. Defaults to False.
             posterize (Optional[int], optional): Posterize the image. Defaults to None.
             vignette (Optional[float], optional): Darken image edges with a radial vignette. Defaults to None.
             keep_alpha (bool, optional): Keep the alpha channel. Defaults to False.
@@ -91,6 +106,7 @@ class Processor:
         self.colorautoadjust = colorautoadjust
         self.colorstretch = colorstretch
         self.grayscale = grayscale
+        self.orthochromatic = orthochromatic
         self.invert = invert
         self.color = color
         self.brightness = brightness
@@ -105,6 +121,10 @@ class Processor:
         self.cyanotype = cyanotype
         self.rochester = rochester
         self.ashigara = ashigara
+        self.crossprocess = crossprocess
+        self.apocalypse = apocalypse
+        self.roppongi = roppongi
+        self.classic = classic
         self.posterize = posterize
         self.vignette = vignette
 
@@ -114,17 +134,64 @@ class Processor:
         else:
             alpha = None
 
+        self._prepare_input()
+        self._apply_input_inversion()
+        self._apply_base_color_correction()
+        self._apply_color_presets()
+        self._apply_manual_adjustments()
+        self._apply_monochrome_presets()
+        self._apply_finishing_adjustments()
+        self._apply_toning()
+        self._apply_output_conversion()
+
+        if alpha is not None:
+            self.image.putalpha(alpha)
+
+        return self.image
+
+    def _prepare_input(self) -> None:
+        """
+        Prepare the image for processing by removing alpha from the working copy.
+        """
         self.image = remove_alpha(self.image)
 
+    def _apply_input_inversion(self) -> None:
+        """
+        Apply early input inversion before color correction.
+        """
         if self.invert:
             self.image = invert(self.image)
 
+    def _apply_base_color_correction(self) -> None:
+        """
+        Apply base color correction operations before film-like color presets.
+        """
         if self.colorautoadjust:
             self.image = color_auto_adjust(self.image)
 
         if self.colorstretch:
             self.image = color_stretch(self.image)
 
+    def _apply_color_presets(self) -> None:
+        """
+        Apply color film presets before monochrome conversion.
+        """
+        if self.rochester:
+            self.image = rochester(self.image)
+
+        if self.ashigara:
+            self.image = ashigara(self.image)
+
+        if self.crossprocess:
+            self.image = cross_process(self.image)
+
+        if self.apocalypse:
+            self.image = apocalypse(self.image)
+
+    def _apply_manual_adjustments(self) -> None:
+        """
+        Apply user-specified color and tone adjustments.
+        """
         if self.color is not None:
             self.image = color(self.image, self.color)
 
@@ -137,9 +204,26 @@ class Processor:
         if self.posterize is not None:
             self.image = posterize(self.image, self.posterize)
 
+    def _apply_monochrome_presets(self) -> None:
+        """
+        Apply monochrome conversion and presets that produce an L image.
+        """
         if self.grayscale:
             self.image = grayscale(self.image)
 
+        if self.orthochromatic:
+            self.image = orthochromatic(self.image)
+
+        if self.roppongi:
+            self.image = roppongi(self.image)
+
+        if self.classic:
+            self.image = classic(self.image)
+
+    def _apply_finishing_adjustments(self) -> None:
+        """
+        Apply final image adjustments before toning and output conversion.
+        """
         if self.contrast is not None:
             self.image = contrast(self.image, self.contrast)
 
@@ -149,8 +233,15 @@ class Processor:
         if self.noise is not None:
             self.image = noise(self.image, self.noise)
 
-        if self.output_rgb:
-            self.image = output_rgb(self.image)
+        if self.vignette is not None:
+            self.image = vignette(self.image, self.vignette)
+
+    def _apply_toning(self) -> None:
+        """
+        Apply toning effects, converting to grayscale first when needed.
+        """
+        if (self.sepia or self.cyanotype) and self.image.mode != "L":
+            self.image = grayscale(self.image)
 
         if self.sepia:
             self.image = sepia(self.image)
@@ -158,16 +249,9 @@ class Processor:
         if self.cyanotype:
             self.image = cyanotype(self.image)
 
-        if self.rochester:
-            self.image = rochester(self.image)
-
-        if self.ashigara:
-            self.image = ashigara(self.image)
-
-        if self.vignette is not None:
-            self.image = vignette(self.image, self.vignette)
-
-        if alpha is not None:
-            self.image.putalpha(alpha)
-
-        return self.image
+    def _apply_output_conversion(self) -> None:
+        """
+        Apply requested final output mode conversion.
+        """
+        if self.output_rgb:
+            self.image = output_rgb(self.image)

--- a/src/anshitsu/process/roppongi.py
+++ b/src/anshitsu/process/roppongi.py
@@ -1,0 +1,92 @@
+import numpy as np
+from PIL import Image, ImageChops
+
+
+def _orthopanchromatic_grayscale(image: Image) -> Image:
+    """
+    Convert an image using a mild orthopanchromatic monochrome response.
+
+    The response is less red-sensitive and more blue-sensitive than the
+    standard luminance conversion, but not as extreme as an orthochromatic
+    conversion.
+
+    Parameters:
+        image: Image
+
+    Returns:
+        Image: converted L mode image.
+    """
+    if image.mode == "L":
+        return image
+
+    rgb = np.array(image.convert("RGB"), dtype="float32")
+
+    gamma = 2.2
+    rgb_l = pow(rgb / 255.0, gamma)
+
+    red = rgb_l[:, :, 0]
+    green = rgb_l[:, :, 1]
+    blue = rgb_l[:, :, 2]
+
+    gray_l = 0.14 * red + 0.68 * green + 0.18 * blue
+    gray = pow(gray_l, 1.0 / gamma) * 255
+
+    return Image.fromarray(gray.astype("uint8"))
+
+
+def _tone_curve(gray: np.ndarray) -> np.ndarray:
+    """
+    Apply a smooth monochrome tone curve with protected highlights.
+
+    Parameters:
+        gray: normalized grayscale image array
+
+    Returns:
+        np.ndarray: tone-adjusted normalized image array.
+    """
+    lifted = np.power(gray, 0.92)
+    blacks = np.clip((lifted - 0.02) / 0.98, 0.0, 1.0)
+    contrast = 3 * blacks**2 - 2 * blacks**3
+
+    highlight_start = 0.78
+    highlights = np.maximum(contrast - highlight_start, 0.0)
+    compressed = highlights / (1.0 + highlights * 2.2)
+    return np.minimum(contrast, highlight_start + compressed)
+
+
+def _add_fine_grain(image: Image, amount: float) -> Image:
+    """
+    Add subtle monochrome grain to an L image.
+
+    Parameters:
+        image: L mode image
+        amount: grain strength
+
+    Returns:
+        Image: grain-adjusted L image.
+    """
+    noise_image = Image.effect_noise(image.size, amount)
+    table = [x * 2 for x in range(256)]
+    return ImageChops.multiply(image, noise_image).point(table)
+
+
+def roppongi(image: Image) -> Image:
+    """
+    Apply a smooth monochrome film preset inspired by Fujifilm ACROS.
+
+    The preset converts the input with a mild orthopanchromatic response,
+    compresses highlights, keeps blacks firm, and adds restrained fine grain.
+    The public preset name avoids trademark use, but the intended rendering is
+    the smooth modern monochrome look associated with ACROS.
+
+    Parameters:
+        image: Image
+
+    Returns:
+        Image: processed image in L mode.
+    """
+    monochrome = _orthopanchromatic_grayscale(image)
+    gray = np.array(monochrome, dtype="float32") / 255.0
+    toned = np.clip(_tone_curve(gray), 0.0, 1.0)
+    processed = Image.fromarray((toned * 255).astype("uint8"))
+    return _add_fine_grain(processed, 2.5)

--- a/tests/test_apocalypse.py
+++ b/tests/test_apocalypse.py
@@ -1,0 +1,78 @@
+import os
+
+from PIL import Image
+
+from anshitsu.process.apocalypse import apocalypse
+from anshitsu.process.processor import Processor
+
+
+def test_apocalypse_returns_rgb_image():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+    processed = apocalypse(image, seed=1)
+
+    assert processed.mode == "RGB"
+
+
+def test_apocalypse_shifts_neutral_toward_red_orange():
+    image = Image.new("RGB", (2, 2), (120, 120, 120))
+    processed = apocalypse(image, seed=1)
+    red, green, blue = processed.getpixel((0, 0))
+
+    assert red > green > blue
+
+
+def test_apocalypse_preserves_highlight_detail():
+    image = Image.new("RGB", (2, 2), (245, 245, 245))
+    processed = apocalypse(image, seed=1)
+
+    assert max(processed.getpixel((0, 0))) < 255
+
+
+def test_apocalypse_seed_is_reproducible():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+
+    first = apocalypse(image, seed=7)
+    second = apocalypse(image, seed=7)
+
+    assert first.tobytes() == second.tobytes()
+
+
+def test_apocalypse_seed_changes_red_shift_strength():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+
+    first = apocalypse(image, seed=7)
+    second = apocalypse(image, seed=8)
+
+    assert first.tobytes() != second.tobytes()
+
+
+def test_apocalypse_by_rgb(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "dog.jpg"),
+    )
+    image = Processor(image=image, apocalypse=True).process()
+    assert image.mode == "RGB"
+
+
+def test_apocalypse_by_grayscale(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "tokyo_station.jpg"),
+    )
+    image = Processor(image=image, apocalypse=True).process()
+    assert image.mode == "RGB"
+
+
+def test_apocalypse_by_rgba(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "nullpo.png"),
+    )
+    image = Processor(image=image, apocalypse=True).process()
+    assert image.mode == "RGB"
+
+
+def test_apocalypse_by_grayscale_with_alpha(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "test.png"),
+    )
+    image = Processor(image=image, apocalypse=True).process()
+    assert image.mode == "RGB"

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -1,0 +1,62 @@
+import os
+
+from PIL import Image
+
+from anshitsu.process.classic import classic
+from anshitsu.process.processor import Processor
+
+
+def test_classic_returns_monochrome_image():
+    image = Image.new("RGB", (8, 8), (128, 128, 128))
+    processed = classic(image)
+
+    assert processed.mode == "L"
+
+
+def test_classic_keeps_highlights_below_white_clip():
+    image = Image.new("RGB", (8, 8), (245, 245, 245))
+    processed = classic(image)
+
+    assert max(processed.getdata()) < 255
+
+
+def test_classic_has_firmer_blacks_than_neutral_gray():
+    dark = Image.new("RGB", (8, 8), (48, 48, 48))
+    middle = Image.new("RGB", (8, 8), (128, 128, 128))
+
+    dark_processed = classic(dark)
+    middle_processed = classic(middle)
+
+    assert min(dark_processed.getdata()) < min(middle_processed.getdata())
+
+
+def test_classic_by_rgb(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "dog.jpg"),
+    )
+    image = Processor(image=image, classic=True).process()
+    assert image.mode == "L"
+
+
+def test_classic_by_grayscale(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "tokyo_station.jpg"),
+    )
+    image = Processor(image=image, classic=True).process()
+    assert image.mode == "L"
+
+
+def test_classic_by_rgba(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "nullpo.png"),
+    )
+    image = Processor(image=image, classic=True).process()
+    assert image.mode == "L"
+
+
+def test_classic_by_grayscale_with_alpha(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "test.png"),
+    )
+    image = Processor(image=image, classic=True).process()
+    assert image.mode == "L"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,41 @@ def test_main_for_ashigara(capsys, setup):
     assert "The cli was completed successfully." in result
 
 
+def test_main_for_crossprocess(capsys, setup):
+    fire.Fire(cli, [str(setup / "dog.jpg"), "--crossprocess"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert "The cli was completed successfully." in result
+
+
+def test_main_for_apocalypse(capsys, setup):
+    fire.Fire(cli, [str(setup / "dog.jpg"), "--apocalypse"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert "The cli was completed successfully." in result
+
+
+def test_main_for_orthochromatic(capsys, setup):
+    fire.Fire(cli, [str(setup / "dog.jpg"), "--orthochromatic"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert "The cli was completed successfully." in result
+
+
+def test_main_for_roppongi(capsys, setup):
+    fire.Fire(cli, [str(setup / "dog.jpg"), "--roppongi"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert "The cli was completed successfully." in result
+
+
+def test_main_for_classic(capsys, setup):
+    fire.Fire(cli, [str(setup / "dog.jpg"), "--classic"])
+    captured = capsys.readouterr()
+    result = captured.out
+    assert "The cli was completed successfully." in result
+
+
 def test_main_for_invalid_directory(capfd, setup):
     with pytest.raises(SystemExit):
         fire.Fire(cli, ["./src/anshitsu/"])

--- a/tests/test_cross_process.py
+++ b/tests/test_cross_process.py
@@ -1,0 +1,70 @@
+import os
+
+from PIL import Image
+
+from anshitsu.process.cross_process import cross_process
+from anshitsu.process.processor import Processor
+
+
+def test_cross_process_returns_rgb_image():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+    processed = cross_process(image, seed=1)
+
+    assert processed.mode == "RGB"
+
+
+def test_cross_process_changes_color():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+    processed = cross_process(image, seed=1)
+
+    assert processed.getpixel((0, 0)) != image.getpixel((0, 0))
+
+
+def test_cross_process_seed_is_reproducible():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+
+    first = cross_process(image, seed=7)
+    second = cross_process(image, seed=7)
+
+    assert first.tobytes() == second.tobytes()
+
+
+def test_cross_process_seed_changes_result():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+
+    first = cross_process(image, seed=7)
+    second = cross_process(image, seed=8)
+
+    assert first.tobytes() != second.tobytes()
+
+
+def test_cross_process_by_rgb(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "dog.jpg"),
+    )
+    image = Processor(image=image, crossprocess=True).process()
+    assert image.mode == "RGB"
+
+
+def test_cross_process_by_grayscale(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "tokyo_station.jpg"),
+    )
+    image = Processor(image=image, crossprocess=True).process()
+    assert image.mode == "RGB"
+
+
+def test_cross_process_by_rgba(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "nullpo.png"),
+    )
+    image = Processor(image=image, crossprocess=True).process()
+    assert image.mode == "RGB"
+
+
+def test_cross_process_by_grayscale_with_alpha(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "test.png"),
+    )
+    image = Processor(image=image, crossprocess=True).process()
+    assert image.mode == "RGB"

--- a/tests/test_orthochromatic.py
+++ b/tests/test_orthochromatic.py
@@ -1,0 +1,50 @@
+import os
+
+from PIL import Image
+
+from anshitsu.process.orthochromatic import orthochromatic
+from anshitsu.process.processor import Processor
+
+
+def test_orthochromatic_darkens_red_more_than_blue():
+    red = Image.new("RGB", (1, 1), (255, 0, 0))
+    blue = Image.new("RGB", (1, 1), (0, 0, 255))
+
+    red_gray = orthochromatic(red)
+    blue_gray = orthochromatic(blue)
+
+    assert red_gray.mode == "L"
+    assert blue_gray.mode == "L"
+    assert red_gray.getpixel((0, 0)) < blue_gray.getpixel((0, 0))
+
+
+def test_orthochromatic_by_rgb(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "dog.jpg"),
+    )
+    image = Processor(image=image, orthochromatic=True).process()
+    assert image.mode == "L"
+
+
+def test_orthochromatic_by_grayscale(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "tokyo_station.jpg"),
+    )
+    image = Processor(image=image, orthochromatic=True).process()
+    assert image.mode == "L"
+
+
+def test_orthochromatic_by_rgba(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "nullpo.png"),
+    )
+    image = Processor(image=image, orthochromatic=True).process()
+    assert image.mode == "L"
+
+
+def test_orthochromatic_by_grayscale_with_alpha(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "test.png"),
+    )
+    image = Processor(image=image, orthochromatic=True).process()
+    assert image.mode == "L"

--- a/tests/test_processor_pipeline.py
+++ b/tests/test_processor_pipeline.py
@@ -1,0 +1,103 @@
+from PIL import Image
+
+from anshitsu.process import processor
+from anshitsu.process.processor import Processor
+
+
+def test_processor_pipeline_order(monkeypatch):
+    calls = []
+
+    def stage(name):
+        def apply(image, *args):
+            calls.append(name)
+            return image
+
+        return apply
+
+    monkeypatch.setattr(processor, "invert", stage("invert"))
+    monkeypatch.setattr(processor, "color_auto_adjust", stage("color_auto_adjust"))
+    monkeypatch.setattr(processor, "color_stretch", stage("color_stretch"))
+    monkeypatch.setattr(processor, "rochester", stage("rochester"))
+    monkeypatch.setattr(processor, "ashigara", stage("ashigara"))
+    monkeypatch.setattr(processor, "cross_process", stage("cross_process"))
+    monkeypatch.setattr(processor, "apocalypse", stage("apocalypse"))
+    monkeypatch.setattr(processor, "color", stage("color"))
+    monkeypatch.setattr(processor, "brightness", stage("brightness"))
+    monkeypatch.setattr(processor, "sharpness", stage("sharpness"))
+    monkeypatch.setattr(processor, "posterize", stage("posterize"))
+
+    def apply_grayscale(image):
+        calls.append("grayscale")
+        return Image.new("L", image.size)
+
+    monkeypatch.setattr(processor, "grayscale", apply_grayscale)
+    monkeypatch.setattr(processor, "orthochromatic", stage("orthochromatic"))
+    monkeypatch.setattr(processor, "roppongi", stage("roppongi"))
+    monkeypatch.setattr(processor, "classic", stage("classic"))
+    monkeypatch.setattr(processor, "contrast", stage("contrast"))
+    monkeypatch.setattr(processor, "line_drawing", stage("line_drawing"))
+    monkeypatch.setattr(processor, "noise", stage("noise"))
+    monkeypatch.setattr(processor, "vignette", stage("vignette"))
+    monkeypatch.setattr(processor, "sepia", stage("sepia"))
+    monkeypatch.setattr(processor, "cyanotype", stage("cyanotype"))
+    monkeypatch.setattr(processor, "output_rgb", stage("output_rgb"))
+
+    Processor(
+        image=Image.new("RGB", (1, 1)),
+        colorautoadjust=True,
+        colorstretch=True,
+        grayscale=True,
+        orthochromatic=True,
+        roppongi=True,
+        classic=True,
+        line_drawing=True,
+        invert=True,
+        outputrgb=True,
+        noise=1.0,
+        color=1.0,
+        brightness=1.0,
+        sharpness=1.0,
+        contrast=1.0,
+        sepia=True,
+        cyanotype=True,
+        rochester=True,
+        ashigara=True,
+        crossprocess=True,
+        apocalypse=True,
+        posterize=4,
+        vignette=0.5,
+    ).process()
+
+    assert calls == [
+        "invert",
+        "color_auto_adjust",
+        "color_stretch",
+        "rochester",
+        "ashigara",
+        "cross_process",
+        "apocalypse",
+        "color",
+        "brightness",
+        "sharpness",
+        "posterize",
+        "grayscale",
+        "orthochromatic",
+        "roppongi",
+        "classic",
+        "contrast",
+        "line_drawing",
+        "noise",
+        "vignette",
+        "sepia",
+        "cyanotype",
+        "output_rgb",
+    ]
+
+
+def test_toning_without_monochrome_preset_uses_grayscale():
+    image = Image.new("RGB", (1, 1), (120, 140, 160))
+
+    processed = Processor(image=image, sepia=True).process()
+
+    assert processed.mode == "RGB"
+    assert processed.getpixel((0, 0)) != image.getpixel((0, 0))

--- a/tests/test_roppongi.py
+++ b/tests/test_roppongi.py
@@ -1,0 +1,63 @@
+import os
+
+from PIL import Image
+
+from anshitsu.process.processor import Processor
+from anshitsu.process.roppongi import _orthopanchromatic_grayscale, roppongi
+
+
+def test_roppongi_returns_monochrome_image():
+    image = Image.new("RGB", (8, 8), (128, 128, 128))
+    processed = roppongi(image)
+
+    assert processed.mode == "L"
+
+
+def test_roppongi_compresses_highlights():
+    image = Image.new("RGB", (8, 8), (245, 245, 245))
+    processed = roppongi(image)
+
+    assert max(processed.getdata()) < 255
+
+
+def test_roppongi_response_is_mildly_orthopanchromatic():
+    red = Image.new("RGB", (1, 1), (255, 0, 0))
+    blue = Image.new("RGB", (1, 1), (0, 0, 255))
+
+    red_gray = _orthopanchromatic_grayscale(red)
+    blue_gray = _orthopanchromatic_grayscale(blue)
+
+    assert red_gray.getpixel((0, 0)) < blue_gray.getpixel((0, 0))
+    assert red_gray.getpixel((0, 0)) > 100
+
+
+def test_roppongi_by_rgb(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "dog.jpg"),
+    )
+    image = Processor(image=image, roppongi=True).process()
+    assert image.mode == "L"
+
+
+def test_roppongi_by_grayscale(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "tokyo_station.jpg"),
+    )
+    image = Processor(image=image, roppongi=True).process()
+    assert image.mode == "L"
+
+
+def test_roppongi_by_rgba(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "nullpo.png"),
+    )
+    image = Processor(image=image, roppongi=True).process()
+    assert image.mode == "L"
+
+
+def test_roppongi_by_grayscale_with_alpha(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "test.png"),
+    )
+    image = Processor(image=image, roppongi=True).process()
+    assert image.mode == "L"


### PR DESCRIPTION
## Summary
- Reorganize the processor into explicit pipeline stages.
- Add orthochromatic grayscale conversion.
- Add monochrome presets: roppongi and classic.
- Add color cross-process presets: crossprocess and apocalypse.
- Add pipeline, CLI, and preset tests.

## Verification
- poetry run pytest
- poetry run flake8 src/ --ignore=E501,E203,W503,W504,F841