### PR TITLE
Add Ultramarine color preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ FLAGS
         Type: bool
         Default: False
         Apply a red-orange Velvia 100 cross-process preset. Defaults to False.
+    --ultramarine=ULTRAMARINE
+        Type: bool
+        Default: False
+        Apply a blue-forward color grade inspired by Kodak Ultramax. Defaults to False.
     --roppongi=ROPPONGI
         Type: bool
         Default: False
@@ -221,6 +225,7 @@ flowchart TD
     colorPresets --> ashigara[ashigara]
     colorPresets --> crossprocess[crossprocess]
     colorPresets --> apocalypse[apocalypse]
+    colorPresets --> ultramarine[ultramarine]
 
     manual --> color[color]
     manual --> brightness[brightness]
@@ -337,6 +342,12 @@ Cross processing can produce unpredictable color shifts depending on film, chemi
 Applies a red-orange cross-process preset inspired by Fujifilm Velvia 100.
 
 This preset leans into the orange-to-red color cast associated with cross-processing Velvia 100. The strength of the red shift varies slightly each time it runs.
+
+### ultramarine
+
+Applies a blue-forward consumer color film grade inspired by Kodak Ultramax.
+
+This preset emphasizes blues while keeping reds slightly restrained, with highlight compression to avoid harsh clipping.
 
 ### noise
 

--- a/src/anshitsu/cli.py
+++ b/src/anshitsu/cli.py
@@ -33,6 +33,7 @@ def cli(
     ashigara: bool = False,
     crossprocess: bool = False,
     apocalypse: bool = False,
+    ultramarine: bool = False,
     roppongi: bool = False,
     classic: bool = False,
     noise: Optional[float] = None,
@@ -78,6 +79,7 @@ def cli(
         ashigara (bool, optional): Apply a vivid color grade inspired by Fujifilm Velvia 100. Defaults to False.
         crossprocess (bool, optional): Apply a random cross-process-style color grade. Defaults to False.
         apocalypse (bool, optional): Apply a red-orange Velvia 100 cross-process preset. Defaults to False.
+        ultramarine (bool, optional): Apply a blue-forward color grade inspired by Kodak Ultramax. Defaults to False.
         roppongi (bool, optional): Apply a smooth fine-grain monochrome preset. Defaults to False.
         classic (bool, optional): Apply a classic high-acutance monochrome preset. Defaults to False.
         noise (Optional[float], optional): Add Gaussian noise. Defaults to None.
@@ -170,6 +172,7 @@ def cli(
             ashigara=ashigara,
             crossprocess=crossprocess,
             apocalypse=apocalypse,
+            ultramarine=ultramarine,
             roppongi=roppongi,
             classic=classic,
             noise=noise,

--- a/src/anshitsu/process/processor.py
+++ b/src/anshitsu/process/processor.py
@@ -25,6 +25,7 @@ from anshitsu.process.roppongi import roppongi
 from anshitsu.process.sepia import sepia
 from anshitsu.process.sharpness import sharpness
 from anshitsu.process.create_alpha_mask import create_alpha_mask
+from anshitsu.process.ultramarine import ultramarine
 from anshitsu.process.vignette import vignette
 
 
@@ -64,6 +65,7 @@ class Processor:
         ashigara: bool = False,
         crossprocess: bool = False,
         apocalypse: bool = False,
+        ultramarine: bool = False,
         roppongi: bool = False,
         classic: bool = False,
         posterize: Optional[int] = None,
@@ -94,6 +96,7 @@ class Processor:
             ashigara (bool, optional): Apply a vivid color grade inspired by Fujifilm Velvia 100. Defaults to False.
             crossprocess (bool, optional): Apply a random cross-process-style color grade. Defaults to False.
             apocalypse (bool, optional): Apply a red-orange Velvia 100 cross-process preset. Defaults to False.
+            ultramarine (bool, optional): Apply a blue-forward color grade inspired by Kodak Ultramax. Defaults to False.
             roppongi (bool, optional): Apply a smooth fine-grain monochrome preset. Defaults to False.
             classic (bool, optional): Apply a classic high-acutance monochrome preset. Defaults to False.
             posterize (Optional[int], optional): Posterize the image. Defaults to None.
@@ -123,6 +126,7 @@ class Processor:
         self.ashigara = ashigara
         self.crossprocess = crossprocess
         self.apocalypse = apocalypse
+        self.ultramarine = ultramarine
         self.roppongi = roppongi
         self.classic = classic
         self.posterize = posterize
@@ -187,6 +191,9 @@ class Processor:
 
         if self.apocalypse:
             self.image = apocalypse(self.image)
+
+        if self.ultramarine:
+            self.image = ultramarine(self.image)
 
     def _apply_manual_adjustments(self) -> None:
         """

--- a/src/anshitsu/process/ultramarine.py
+++ b/src/anshitsu/process/ultramarine.py
@@ -1,0 +1,55 @@
+import numpy as np
+from PIL import Image
+
+
+def _soft_clip_highlights(image_array: np.ndarray) -> np.ndarray:
+    """
+    Compress bright tones to keep the blue-leaning grade from clipping.
+
+    Parameters:
+        image_array: normalized RGB image array
+
+    Returns:
+        np.ndarray: highlight-compressed normalized RGB image array.
+    """
+    highlight_start = 0.80
+    compression = 3.2
+    highlights = np.maximum(image_array - highlight_start, 0.0)
+    compressed = highlights / (1.0 + highlights * compression)
+    return np.minimum(image_array, highlight_start + compressed)
+
+
+def ultramarine(image: Image) -> Image:
+    """
+    Apply a blue-forward consumer color film grade inspired by Kodak Ultramax.
+
+    The preset keeps a punchy snapshot-film look with stronger blues, slightly
+    restrained reds, lively saturation, and protected highlights.
+
+    Returns:
+        Image: processed RGB image.
+    """
+    image_array = np.array(image.convert("RGB"), dtype="float32") / 255.0
+
+    image_array = np.power(np.clip(image_array, 0.0, 1.0), (0.98, 0.96, 0.90))
+    image_array = (image_array - 0.5) * 1.045 + 0.5
+
+    red = image_array[:, :, 0] * 0.985 - 0.004
+    green = image_array[:, :, 1] * 1.015 + 0.002
+    blue = image_array[:, :, 2] * 1.09 + 0.018
+    image_array = np.stack((red, green, blue), axis=2)
+
+    luminance = (
+        image_array[:, :, 0] * 0.299
+        + image_array[:, :, 1] * 0.587
+        + image_array[:, :, 2] * 0.114
+    )
+    saturation = 1.12
+    image_array = (
+        luminance[:, :, np.newaxis]
+        + (image_array - luminance[:, :, np.newaxis]) * saturation
+    )
+
+    image_array = _soft_clip_highlights(image_array)
+    image_array = np.clip(image_array, 0.0, 0.992)
+    return Image.fromarray((image_array * 255).astype("uint8"))

--- a/tests/test_processor_pipeline.py
+++ b/tests/test_processor_pipeline.py
@@ -21,6 +21,7 @@ def test_processor_pipeline_order(monkeypatch):
     monkeypatch.setattr(processor, "ashigara", stage("ashigara"))
     monkeypatch.setattr(processor, "cross_process", stage("cross_process"))
     monkeypatch.setattr(processor, "apocalypse", stage("apocalypse"))
+    monkeypatch.setattr(processor, "ultramarine", stage("ultramarine"))
     monkeypatch.setattr(processor, "color", stage("color"))
     monkeypatch.setattr(processor, "brightness", stage("brightness"))
     monkeypatch.setattr(processor, "sharpness", stage("sharpness"))
@@ -64,6 +65,7 @@ def test_processor_pipeline_order(monkeypatch):
         ashigara=True,
         crossprocess=True,
         apocalypse=True,
+        ultramarine=True,
         posterize=4,
         vignette=0.5,
     ).process()
@@ -76,6 +78,7 @@ def test_processor_pipeline_order(monkeypatch):
         "ashigara",
         "cross_process",
         "apocalypse",
+        "ultramarine",
         "color",
         "brightness",
         "sharpness",

--- a/tests/test_ultramarine.py
+++ b/tests/test_ultramarine.py
@@ -1,0 +1,60 @@
+import os
+
+from PIL import Image
+
+from anshitsu.process.processor import Processor
+from anshitsu.process.ultramarine import ultramarine
+
+
+def test_ultramarine_returns_rgb_image():
+    image = Image.new("RGB", (2, 2), (120, 130, 140))
+    processed = ultramarine(image)
+
+    assert processed.mode == "RGB"
+
+
+def test_ultramarine_shifts_neutral_toward_blue():
+    image = Image.new("RGB", (2, 2), (120, 120, 120))
+    processed = ultramarine(image)
+    red, green, blue = processed.getpixel((0, 0))
+
+    assert blue > green > red
+
+
+def test_ultramarine_preserves_highlight_detail():
+    image = Image.new("RGB", (2, 2), (245, 245, 245))
+    processed = ultramarine(image)
+
+    assert max(processed.getpixel((0, 0))) < 255
+
+
+def test_ultramarine_by_rgb(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "dog.jpg"),
+    )
+    image = Processor(image=image, ultramarine=True).process()
+    assert image.mode == "RGB"
+
+
+def test_ultramarine_by_grayscale(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "tokyo_station.jpg"),
+    )
+    image = Processor(image=image, ultramarine=True).process()
+    assert image.mode == "RGB"
+
+
+def test_ultramarine_by_rgba(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "nullpo.png"),
+    )
+    image = Processor(image=image, ultramarine=True).process()
+    assert image.mode == "RGB"
+
+
+def test_ultramarine_by_grayscale_with_alpha(setup):
+    image = Image.open(
+        os.path.join(".", "tests", "pic", "test.png"),
+    )
+    image = Processor(image=image, ultramarine=True).process()
+    assert image.mode == "RGB"


### PR DESCRIPTION
## Summary
- Add an Ultramarine color preset inspired by Kodak Ultramax.
- Wire the preset into the CLI, Processor pipeline, README, and processing flow docs.
- Add tests for blue-forward color shift, highlight protection, Processor integration, and pipeline order.

## Tests
- poetry run black src/anshitsu/process/ultramarine.py src/anshitsu/process/processor.py src/anshitsu/cli.py tests/test_ultramarine.py tests/test_processor_pipeline.py
- poetry run pytest tests/test_ultramarine.py tests/test_processor_pipeline.py tests/test_cli.py
- git diff --check