### PR TITLE
Fix release asset upload source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Download Release Assets
         uses: actions/download-artifact@v4
         with:
+          name: anshitsu-python-dist
           path: release-assets
       - name: Create GitHub Release
         env:
@@ -120,14 +121,15 @@ jobs:
           RELEASE_NOTE: ${{ github.event.inputs.release_note }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
+          mapfile -t ASSETS < <(find release-assets -type f | sort)
           if [ -n "${RELEASE_NOTE}" ]; then
             printf "%s\n" "${RELEASE_NOTE}" > RELEASE_NOTES.md
-            gh release create "${TAG}" release-assets/**/* \
+            gh release create "${TAG}" "${ASSETS[@]}" \
               --target "${GITHUB_SHA}" \
               --title "${TAG}" \
               --notes-file RELEASE_NOTES.md
           else
-            gh release create "${TAG}" release-assets/**/* \
+            gh release create "${TAG}" "${ASSETS[@]}" \
               --target "${GITHUB_SHA}" \
               --title "${TAG}" \
               --generate-notes


### PR DESCRIPTION
## Summary
- Download only the published Python distribution artifact in the release creation job.
- Pass an explicit sorted file list to gh release create instead of a broad glob.

## Context
- v3.2.0 successfully published to PyPI, but the release creation job failed while uploading assets.
- The GitHub Release was completed manually for v3.2.0.

## Tests
- git diff --check