### PR TITLE
[codex] Use full-image ACE sampling for 3.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anshitsu"
-version = "3.2.0"  # using poetry-dynamic-versioning
+version = "3.2.1"  # using poetry-dynamic-versioning
 description = "A tiny digital photographic utility."
 readme = "README.md"
 authors = ["Iosif Takakura <iosif@huideyeren.info>"]

--- a/src/anshitsu/__version__.py
+++ b/src/anshitsu/__version__.py
@@ -1,1 +1,1 @@
-version: str = "v2.0.2"
+version: str = "v3.2.1"

--- a/src/anshitsu/process/_native_color.py
+++ b/src/anshitsu/process/_native_color.py
@@ -9,7 +9,7 @@ from PIL import Image
 
 def automatic_color_equalization(
     image: Image,
-    samples: int = 500,
+    samples: Optional[int] = None,
     slope: float = 10.0,
     limit: float = 1000.0,
 ) -> Optional[Image]:
@@ -19,6 +19,7 @@ def automatic_color_equalization(
     Args:
         image: RGB image to process.
         samples: Maximum number of spatial samples used for ACE comparison.
+            When omitted, every image pixel is used.
         slope: Slope applied to channel differences before clipping.
         limit: Maximum absolute contrast contribution.
 
@@ -31,6 +32,7 @@ def automatic_color_equalization(
 
     rgb_image = image.convert("RGB")
     width, height = rgb_image.size
+    sample_count = samples if samples is not None else width * height
     buffer = bytearray(rgb_image.tobytes())
     array_type = ctypes.c_ubyte * len(buffer)
     c_buffer = array_type.from_buffer(buffer)
@@ -40,7 +42,7 @@ def automatic_color_equalization(
         ctypes.c_size_t(len(buffer)),
         ctypes.c_size_t(width),
         ctypes.c_size_t(height),
-        ctypes.c_size_t(samples),
+        ctypes.c_size_t(sample_count),
         ctypes.c_float(slope),
         ctypes.c_float(limit),
     )

--- a/src/anshitsu/process/color_auto_adjust.py
+++ b/src/anshitsu/process/color_auto_adjust.py
@@ -20,4 +20,7 @@ def color_auto_adjust(image: Image) -> Image:
     native_image = _native_color.automatic_color_equalization(image)
     if native_image is not None:
         return native_image
-    return to_pil(cca.automatic_color_equalization(from_pil(image)))
+    width, height = image.size
+    return to_pil(
+        cca.automatic_color_equalization(from_pil(image), samples=width * height)
+    )

--- a/tests/test_colorautoadjust.py
+++ b/tests/test_colorautoadjust.py
@@ -2,13 +2,14 @@ import os
 
 from PIL import Image
 
+from anshitsu.process import _native_color
 from anshitsu.process.processor import Processor
 
 
 def test_colorautoadjust_by_rgb(setup):
     image = Image.open(
         os.path.join(".", "tests", "pic", "dog.jpg"),
-    )
+    ).resize((8, 8))
     image = Processor(image=image, colorautoadjust=True).process()
     assert image.mode == "RGB"
 
@@ -16,7 +17,7 @@ def test_colorautoadjust_by_rgb(setup):
 def test_colorautoadjust_by_grayscale(setup):
     image = Image.open(
         os.path.join(".", "tests", "pic", "tokyo_station.jpg"),
-    )
+    ).resize((8, 8))
     image = Processor(image=image, colorautoadjust=True).process()
     assert image.mode == "L"
 
@@ -24,7 +25,7 @@ def test_colorautoadjust_by_grayscale(setup):
 def test_colorautoadjust_by_rgba(setup):
     image = Image.open(
         os.path.join(".", "tests", "pic", "nullpo.png"),
-    )
+    ).resize((8, 8))
     image = Processor(image=image, colorautoadjust=True).process()
     assert image.mode == "RGB"
 
@@ -32,6 +33,42 @@ def test_colorautoadjust_by_rgba(setup):
 def test_colorautoadjust_by_grayscale_with_alpha(setup):
     image = Image.open(
         os.path.join(".", "tests", "pic", "test.png"),
-    )
+    ).resize((8, 8))
     image = Processor(image=image, colorautoadjust=True).process()
     assert image.mode == "L"
+
+
+def test_colorautoadjust_uses_all_pixels_by_default(monkeypatch):
+    captured = {}
+
+    def native_color_auto_adjust(image, samples=None):
+        captured["samples"] = samples
+        return image.convert("RGB")
+
+    monkeypatch.setattr(
+        "anshitsu.process._native_color.automatic_color_equalization",
+        native_color_auto_adjust,
+    )
+    image = Image.new("RGB", (3, 2), (128, 128, 128))
+
+    Processor(image=image, colorautoadjust=True).process()
+
+    assert captured["samples"] is None
+
+
+def test_native_colorautoadjust_resolves_default_samples_to_all_pixels(monkeypatch):
+    captured = {}
+
+    class FakeLibrary:
+        def anshitsu_ace_rgb(
+            self, buffer, data_len, width, height, samples, slope, limit
+        ):
+            captured["samples"] = samples.value
+            return 0
+
+    monkeypatch.setattr(_native_color, "_load_library", lambda: FakeLibrary())
+    image = Image.new("RGB", (3, 2), (128, 128, 128))
+
+    _native_color.automatic_color_equalization(image)
+
+    assert captured["samples"] == 6


### PR DESCRIPTION
## Summary

- Change Automatic Color Equalization to use every image pixel as the default sample set instead of the previous 500-point grid.
- Keep the Python fallback behavior aligned by passing width * height samples to colorcorrect.
- Bump the package/runtime version to 3.2.1.
- Add tests covering the default all-pixel sample resolution while keeping existing mode checks lightweight.

## Why

The previous fixed-grid sampling leaked into processed images as regularly spaced dot artifacts, especially on smooth dark regions such as the emperor portraits' hats. Using the full image removes that sampling grid from the ACE calculation at the cost of much heavier processing.

## Validation

- .venv/bin/python -m pytest tests/test_colorautoadjust.py