### PR TITLE
Use correction maps for native ACE

### DIFF
--- a/native/anshitsu-color/src/lib.rs
+++ b/native/anshitsu-color/src/lib.rs
@@ -1,6 +1,11 @@
 use std::cmp::max;
 use std::slice;
 
+const ACE_WORKING_LONG_EDGE: usize = 96;
+const ACE_CORRECTION_STRENGTH: f32 = 0.68;
+const ACE_CORRECTION_LIMIT: f32 = 42.0;
+const ACE_NEGATIVE_CORRECTION_SCALE: f32 = 0.38;
+
 #[derive(Clone, Copy)]
 struct Sample {
     x: usize,
@@ -32,6 +37,21 @@ pub fn automatic_color_equalization_rgb(
         return Err("buffer length does not match RGB image dimensions");
     }
 
+    if sample_limit >= pixels && max(width, height) > ACE_WORKING_LONG_EDGE {
+        return automatic_color_equalization_with_correction_map(data, width, height, slope, limit);
+    }
+
+    automatic_color_equalization_direct(data, width, height, sample_limit, slope, limit)
+}
+
+fn automatic_color_equalization_direct(
+    data: &mut [u8],
+    width: usize,
+    height: usize,
+    sample_limit: usize,
+    slope: f32,
+    limit: f32,
+) -> Result<(), &'static str> {
     let samples = collect_samples(data, width, height, sample_limit);
     if samples.is_empty() {
         return Ok(());
@@ -94,6 +114,250 @@ pub fn automatic_color_equalization_rgb(
     }
 
     Ok(())
+}
+
+fn automatic_color_equalization_with_correction_map(
+    data: &mut [u8],
+    width: usize,
+    height: usize,
+    slope: f32,
+    limit: f32,
+) -> Result<(), &'static str> {
+    let (map_width, map_height) = working_size(width, height, ACE_WORKING_LONG_EDGE);
+    let source_map = resize_rgb(data, width, height, map_width, map_height);
+    let mut adjusted_map = source_map.clone();
+    automatic_color_equalization_direct(
+        &mut adjusted_map,
+        map_width,
+        map_height,
+        map_width * map_height,
+        slope,
+        limit,
+    )?;
+
+    let mut correction_map = correction_map(&source_map, &adjusted_map);
+    smooth_correction_map(&mut correction_map, map_width, map_height);
+    apply_correction_map(data, width, height, &correction_map, map_width, map_height);
+    Ok(())
+}
+
+fn working_size(width: usize, height: usize, long_edge: usize) -> (usize, usize) {
+    let current_long_edge = max(width, height);
+    if current_long_edge <= long_edge {
+        return (width, height);
+    }
+
+    if width >= height {
+        let map_width = long_edge;
+        let map_height = max(1, (height * long_edge + width / 2) / width);
+        (map_width, map_height)
+    } else {
+        let map_height = long_edge;
+        let map_width = max(1, (width * long_edge + height / 2) / height);
+        (map_width, map_height)
+    }
+}
+
+fn resize_rgb(
+    data: &[u8],
+    width: usize,
+    height: usize,
+    target_width: usize,
+    target_height: usize,
+) -> Vec<u8> {
+    let mut resized = vec![0_u8; target_width * target_height * 3];
+
+    for y in 0..target_height {
+        let source_y = mapped_coordinate(y, target_height, height);
+        for x in 0..target_width {
+            let source_x = mapped_coordinate(x, target_width, width);
+            let source_index = (source_y * width + source_x) * 3;
+            let target_index = (y * target_width + x) * 3;
+            resized[target_index..target_index + 3]
+                .copy_from_slice(&data[source_index..source_index + 3]);
+        }
+    }
+
+    resized
+}
+
+fn correction_map(source: &[u8], adjusted: &[u8]) -> Vec<f32> {
+    source
+        .iter()
+        .zip(adjusted)
+        .map(|(before, after)| *after as f32 - *before as f32)
+        .collect()
+}
+
+fn smooth_correction_map(correction_map: &mut [f32], width: usize, height: usize) {
+    if width <= 1 || height <= 1 {
+        return;
+    }
+
+    let original = correction_map.to_vec();
+    for y in 0..height {
+        for x in 0..width {
+            for channel in 0..3 {
+                let mut total = 0.0_f32;
+                let mut weight_total = 0.0_f32;
+
+                for offset_y in -1_i32..=1 {
+                    for offset_x in -1_i32..=1 {
+                        let sample_x = clamp_offset(x, offset_x, width);
+                        let sample_y = clamp_offset(y, offset_y, height);
+                        let weight = if offset_x == 0 && offset_y == 0 {
+                            4.0
+                        } else if offset_x == 0 || offset_y == 0 {
+                            2.0
+                        } else {
+                            1.0
+                        };
+                        total += correction_value(&original, width, sample_x, sample_y, channel)
+                            * weight;
+                        weight_total += weight;
+                    }
+                }
+
+                correction_map[(y * width + x) * 3 + channel] = total / weight_total;
+            }
+        }
+    }
+}
+
+fn clamp_offset(position: usize, offset: i32, limit: usize) -> usize {
+    if offset < 0 {
+        position.saturating_sub(offset.unsigned_abs() as usize)
+    } else {
+        (position + offset as usize).min(limit - 1)
+    }
+}
+
+fn apply_correction_map(
+    data: &mut [u8],
+    width: usize,
+    height: usize,
+    correction_map: &[f32],
+    map_width: usize,
+    map_height: usize,
+) {
+    for y in 0..height {
+        let (y0, y1, y_weight) = interpolation_axis(y, height, map_height);
+        for x in 0..width {
+            let (x0, x1, x_weight) = interpolation_axis(x, width, map_width);
+            let pixel_index = (y * width + x) * 3;
+            let luminance = data[pixel_index] as f32 * 0.299
+                + data[pixel_index + 1] as f32 * 0.587
+                + data[pixel_index + 2] as f32 * 0.114;
+            let shadow_weight = shadow_correction_weight(luminance);
+
+            for channel in 0..3 {
+                let top_left = correction_value(correction_map, map_width, x0, y0, channel);
+                let top_right = correction_value(correction_map, map_width, x1, y0, channel);
+                let bottom_left = correction_value(correction_map, map_width, x0, y1, channel);
+                let bottom_right = correction_value(correction_map, map_width, x1, y1, channel);
+                let top = top_left + (top_right - top_left) * x_weight;
+                let bottom = bottom_left + (bottom_right - bottom_left) * x_weight;
+                let mut correction = (top + (bottom - top) * y_weight)
+                    .clamp(-ACE_CORRECTION_LIMIT, ACE_CORRECTION_LIMIT);
+                if correction < 0.0 {
+                    correction *= ACE_NEGATIVE_CORRECTION_SCALE
+                        * local_darkening_weight(data, width, height, x, y, luminance);
+                }
+                correction *= ACE_CORRECTION_STRENGTH * shadow_weight;
+                let value = data[pixel_index + channel] as f32 + correction;
+                data[pixel_index + channel] = value.round().clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+}
+
+fn shadow_correction_weight(luminance: f32) -> f32 {
+    let normalized = (luminance / 255.0).clamp(0.0, 1.0);
+    0.35 + 0.65 * smoothstep(0.08, 0.42, normalized)
+}
+
+fn local_darkening_weight(
+    data: &[u8],
+    width: usize,
+    height: usize,
+    x: usize,
+    y: usize,
+    luminance: f32,
+) -> f32 {
+    let x_start = x.saturating_sub(1);
+    let y_start = y.saturating_sub(1);
+    let x_end = (x + 1).min(width - 1);
+    let y_end = (y + 1).min(height - 1);
+    let mut total = 0.0_f32;
+    let mut count = 0.0_f32;
+    let mut min_luminance = luminance;
+    let mut max_luminance = luminance;
+
+    for sample_y in y_start..=y_end {
+        for sample_x in x_start..=x_end {
+            if sample_x == x && sample_y == y {
+                continue;
+            }
+            let value = pixel_luminance(data, width, sample_x, sample_y);
+            total += value;
+            count += 1.0;
+            min_luminance = min_luminance.min(value);
+            max_luminance = max_luminance.max(value);
+        }
+    }
+
+    if count <= 0.0 {
+        return 1.0;
+    }
+
+    let average = total / count;
+    let contrast = max_luminance - min_luminance;
+    let dark_gap = (average - luminance).max(0.0);
+    let edge_strength = smoothstep(18.0, 72.0, contrast) * smoothstep(6.0, 32.0, dark_gap);
+    1.0 - 0.78 * edge_strength
+}
+
+fn pixel_luminance(data: &[u8], width: usize, x: usize, y: usize) -> f32 {
+    let index = (y * width + x) * 3;
+    data[index] as f32 * 0.299 + data[index + 1] as f32 * 0.587 + data[index + 2] as f32 * 0.114
+}
+
+fn smoothstep(edge0: f32, edge1: f32, value: f32) -> f32 {
+    if edge0 >= edge1 {
+        return 0.0;
+    }
+    let x = ((value - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    x * x * (3.0 - 2.0 * x)
+}
+
+fn correction_value(
+    correction_map: &[f32],
+    map_width: usize,
+    x: usize,
+    y: usize,
+    channel: usize,
+) -> f32 {
+    correction_map[(y * map_width + x) * 3 + channel]
+}
+
+fn interpolation_axis(position: usize, length: usize, map_length: usize) -> (usize, usize, f32) {
+    if map_length <= 1 || length <= 1 {
+        return (0, 0, 0.0);
+    }
+
+    let numerator = position * (map_length - 1);
+    let denominator = length - 1;
+    let lower = numerator / denominator;
+    let upper = (lower + 1).min(map_length - 1);
+    let weight = (numerator % denominator) as f32 / denominator as f32;
+    (lower, upper, weight)
+}
+
+fn mapped_coordinate(position: usize, length: usize, source_length: usize) -> usize {
+    if length <= 1 || source_length <= 1 {
+        return 0;
+    }
+    (position * (source_length - 1) + (length - 1) / 2) / (length - 1)
 }
 
 /// Apply gray-world white balance followed by per-channel color stretching.
@@ -275,7 +539,7 @@ pub unsafe extern "C" fn anshitsu_color_stretch_rgb(
 
 #[cfg(test)]
 mod tests {
-    use super::{automatic_color_equalization_rgb, color_stretch_rgb};
+    use super::{automatic_color_equalization_rgb, color_stretch_rgb, local_darkening_weight};
 
     #[test]
     fn keeps_constant_images_stable() {
@@ -298,6 +562,48 @@ mod tests {
         let mut data = vec![0_u8; 5];
         let result = automatic_color_equalization_rgb(&mut data, 2, 1, 2, 10.0, 1000.0);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn correction_map_path_keeps_large_constant_images_stable() {
+        let width = 128;
+        let height = 1;
+        let mut data = vec![128_u8; width * height * 3];
+
+        automatic_color_equalization_rgb(&mut data, width, height, width * height, 10.0, 1000.0)
+            .unwrap();
+
+        assert_eq!(data, vec![128_u8; width * height * 3]);
+    }
+
+    #[test]
+    fn correction_map_path_processes_large_gradients() {
+        let width = 128;
+        let height = 1;
+        let mut data = Vec::with_capacity(width * height * 3);
+        for x in 0..width {
+            let value = (x * 255 / (width - 1)) as u8;
+            data.extend_from_slice(&[value, value.saturating_div(2), 255 - value]);
+        }
+
+        automatic_color_equalization_rgb(&mut data, width, height, width * height, 10.0, 1000.0)
+            .unwrap();
+
+        assert_eq!(data.len(), width * height * 3);
+        assert_eq!(data.iter().min(), Some(&0));
+        assert_eq!(data.iter().max(), Some(&255));
+    }
+
+    #[test]
+    fn local_darkening_weight_suppresses_dark_edges() {
+        let data = vec![
+            192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 16, 16, 16, 192, 192, 192,
+            192, 192, 192, 192, 192, 192, 192, 192, 192,
+        ];
+
+        let weight = local_darkening_weight(&data, 3, 3, 1, 1, 16.0);
+
+        assert!(weight < 0.5);
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anshitsu"
-version = "3.2.1"  # using poetry-dynamic-versioning
+version = "3.2.2"  # using poetry-dynamic-versioning
 description = "A tiny digital photographic utility."
 readme = "README.md"
 authors = ["Iosif Takakura <iosif@huideyeren.info>"]

--- a/src/anshitsu/__version__.py
+++ b/src/anshitsu/__version__.py
@@ -1,1 +1,1 @@
-version: str = "v3.2.1"
+version: str = "v3.2.2"

--- a/src/anshitsu/process/_native_color.py
+++ b/src/anshitsu/process/_native_color.py
@@ -125,9 +125,7 @@ def _find_library_path() -> Optional[Path]:
             return path
 
     library_name = _library_name()
-    candidates = [
-        Path(__file__).resolve().parents[1] / "_native" / library_name,
-    ]
+    candidates = []
     repository_root = _repository_root()
     if repository_root is not None:
         candidates.append(
@@ -146,6 +144,8 @@ def _find_library_path() -> Optional[Path]:
             / "debug"
             / library_name
         )
+
+    candidates.append(Path(__file__).resolve().parents[1] / "_native" / library_name)
 
     for candidate in candidates:
         if candidate.exists():


### PR DESCRIPTION
## Summary
- run native ACE on a 96px correction map for full-pixel ACE requests
- smooth and clamp the correction map before applying it to full-size images
- dampen negative corrections in shadows and dark contour edges to avoid black speckling
- bump version to 3.2.2

## Tests
- cargo test --manifest-path native/anshitsu-color/Cargo.toml
- cargo build --release --manifest-path native/anshitsu-color/Cargo.toml
- poetry run pytest tests/test_colorautoadjust.py tests/test_colorstretch.py
- git diff --check